### PR TITLE
Use both variables of the documents on windows env

### DIFF
--- a/build.py
+++ b/build.py
@@ -38,13 +38,19 @@ def build():
 		# Installed with 'npm install -g luabundler'
 		#luabundler = 'luabundler'
 	elif platform_system == 'Windows':
-		app_dir = os.path.join(os.environ['USERPROFILE'], 'Documents', 'My Games')
-		app_dir = os.path.join(os.environ['USERPROFILE'], 'OneDrive', 'Documents', 'My Games')
-		# Installed with 'npm install -g luabundler'
-		luabundler = 'luabundler.cmd'
-	else:
-		print('Unknown os: ' + platform_system, file = sys.stderr)
-		exit(1)
+		# Define both potential paths
+		one_drive_path = os.path.join(os.environ['USERPROFILE'], 'OneDrive', 'Documents', 'My Games')
+		documents_path = os.path.join(os.environ['USERPROFILE'], 'Documents', 'My Games')
+
+		# Check which path exists, prioritizing OneDrive if both are available
+		if os.path.exists(one_drive_path):
+			app_dir = one_drive_path
+		elif os.path.exists(documents_path):
+			app_dir = documents_path
+		else:
+			print("No valid 'My Games' directory found.", file=sys.stderr)
+			exit(1)
+
 
 	tts_save_dir = os.path.join(app_dir, 'Tabletop Simulator', 'Saves')
 


### PR DESCRIPTION
This PR enhances the Windows-specific path selection logic in the build function by conditionally selecting between two potential paths for the My Games directory. On Windows, the My Games folder might reside in either the Documents folder or within OneDrive. This change prioritizes the OneDrive\Documents\My Games directory when available and falls back to Documents\My Games if OneDrive is not set up or synced.